### PR TITLE
feat: スマートフォンの縦画面時に横画面への回転を促す

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 import { Routes, Route } from "react-router-dom";
 import { Layout } from "@/components/layout/Layout";
+import { OrientationGuard } from "@/components/layout/OrientationGuard";
 import { useAuthInit } from "@/hooks/useAuthInit";
 import { AuthGuard } from "@/components/auth/AuthGuard";
 import { useAsciiArt } from "./hooks/useAsciiArt";
@@ -16,25 +17,28 @@ function App() {
   useAsciiArt();
 
   return (
-    <Layout>
-      <Suspense fallback={<div className="loading-page">読み込み中...</div>}>
-        <Routes>
-          <Route path="/" element={<FaceDetectionPage />} />
-          <Route path="/expressions" element={<ExpressionsPage />} />
-          <Route path="/editor" element={<DotEditorPage />} />
-          <Route path="/editor/:id" element={<DotEditorPage />} />
-          <Route path="/gallery" element={<GalleryPage />} />
-          <Route
-            path="/profile"
-            element={
-              <AuthGuard>
-                <ProfilePage />
-              </AuthGuard>
-            }
-          />
-        </Routes>
-      </Suspense>
-    </Layout>
+    <>
+      <OrientationGuard />
+      <Layout>
+        <Suspense fallback={<div className="loading-page">読み込み中...</div>}>
+          <Routes>
+            <Route path="/" element={<FaceDetectionPage />} />
+            <Route path="/expressions" element={<ExpressionsPage />} />
+            <Route path="/editor" element={<DotEditorPage />} />
+            <Route path="/editor/:id" element={<DotEditorPage />} />
+            <Route path="/gallery" element={<GalleryPage />} />
+            <Route
+              path="/profile"
+              element={
+                <AuthGuard>
+                  <ProfilePage />
+                </AuthGuard>
+              }
+            />
+          </Routes>
+        </Suspense>
+      </Layout>
+    </>
   );
 }
 

--- a/src/components/layout/OrientationGuard.tsx
+++ b/src/components/layout/OrientationGuard.tsx
@@ -1,0 +1,80 @@
+import { useOrientationLock } from "@/hooks/useOrientationLock";
+
+/**
+ * スマートフォンで縦画面のとき、横画面への回転を促すオーバーレイを表示するコンポーネント
+ * タブレット（幅 >= 768px）ではオーバーレイを表示しない
+ */
+export function OrientationGuard() {
+  const isPortrait = useOrientationLock();
+
+  // タブレット以上の幅ではチェック不要（CSS側でも制御）
+  // isPortraitがfalse（横画面）なら何も表示しない
+  if (!isPortrait) return null;
+
+  return (
+    <>
+      {/* スマートフォンの縦画面のみ表示（CSSでタブレット以上を非表示） */}
+      <div
+        className="orientation-guard"
+        style={{
+          position: "fixed",
+          inset: 0,
+          zIndex: 9999,
+          backgroundColor: "#1a1225",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "24px",
+          color: "#f5f0ff",
+          fontFamily: "'DotGothic16', 'Courier New', monospace",
+        }}
+      >
+        {/* 回転アイコン（CSSアニメーション） */}
+        <div
+          style={{
+            fontSize: "64px",
+            animation: "rotate-hint 2s ease-in-out infinite",
+          }}
+        >
+          📱
+        </div>
+        <p
+          style={{
+            fontSize: "18px",
+            fontWeight: "bold",
+            color: "#e66cbc",
+            textAlign: "center",
+            margin: 0,
+            textShadow: "0 0 8px rgba(230, 108, 188, 0.5)",
+          }}
+        >
+          横画面にしてください
+        </p>
+        <p
+          style={{
+            fontSize: "14px",
+            color: "#a89bbe",
+            textAlign: "center",
+            margin: 0,
+          }}
+        >
+          このアプリは横画面専用です
+        </p>
+        <style>{`
+          @keyframes rotate-hint {
+            0%, 100% { transform: rotate(0deg); }
+            40% { transform: rotate(90deg); }
+            60% { transform: rotate(90deg); }
+          }
+          /* タブレット以上ではオーバーレイを非表示 */
+          @media (min-width: 768px) {
+            .orientation-guard {
+              display: none !important;
+            }
+          }
+        `}</style>
+      </div>
+    </>
+  );
+}

--- a/src/hooks/useOrientationLock.ts
+++ b/src/hooks/useOrientationLock.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from "react";
+
+/**
+ * 画面の向きを検出するhook
+ *
+ * @returns isPortrait - 縦画面(portrait)の場合true
+ */
+export const useOrientationLock = (): boolean => {
+  const getIsPortrait = () => {
+    if (typeof window === "undefined") return false;
+    // screen.orientation APIが利用可能な場合はそちらを優先
+    if (window.screen?.orientation) {
+      return window.screen.orientation.type.startsWith("portrait");
+    }
+    return window.innerHeight > window.innerWidth;
+  };
+
+  const [isPortrait, setIsPortrait] = useState<boolean>(getIsPortrait);
+
+  useEffect(() => {
+    const handleChange = () => {
+      setIsPortrait(getIsPortrait());
+    };
+
+    if (window.screen?.orientation) {
+      window.screen.orientation.addEventListener("change", handleChange);
+    }
+    window.addEventListener("resize", handleChange);
+
+    return () => {
+      if (window.screen?.orientation) {
+        window.screen.orientation.removeEventListener("change", handleChange);
+      }
+      window.removeEventListener("resize", handleChange);
+    };
+  }, []);
+
+  return isPortrait;
+};


### PR DESCRIPTION
## 概要

Issue #14「横画面を強制する」の対応。
スマートフォンで縦向きに持ったとき、横画面への回転を促すオーバーレイを表示します。

## 変更内容

- `src/hooks/useOrientationLock.ts` を新規追加
  - `screen.orientation` API（優先）または `innerWidth/innerHeight` で縦横を検出
  - 向き変更時に自動でstateを更新
- `src/components/layout/OrientationGuard.tsx` を新規追加
  - 縦画面時に全画面オーバーレイを表示
  - 📱アイコンが90度回転するCSSアニメーションで横回転を視覚的に案内
  - タブレット以上（幅 ≥ 768px）では `@media` でオーバーレイを非表示
- `src/App.tsx` に `<OrientationGuard />` を追加（zIndex: 9999 で最前面）

## テスト

- [ ] スマートフォン縦向き → オーバーレイが表示される
- [ ] スマートフォン横向き → オーバーレイが非表示（アプリが通常表示）
- [ ] タブレット/PC → オーバーレイが表示されない（幅 ≥ 768px）
- [ ] ビルドが正常に通ること（`npm run build`）

## 関連 Issue

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* モバイルデバイスを縦向きで使用する際に、横向きへの回転を促すガイダンスがオーバーレイで表示されるようになりました。タブレット以上のサイズでは自動的に非表示になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->